### PR TITLE
Change sinatra version

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ You can look for output on `/var/log/cloud-init-output.log` or `/var/log/cloud-i
 To change diferent user-data configs, change the file `/vagrant/user_data.txt` at your heart's content .
 
 ### Vagrant tools
-http://stackoverflow.com/questions/42074246/vagrant-error-unable-to-mount-virtualbox-shared-folders-guest-additions-vboxs
+If you have any errors while using vagrant up, Install virtual box guest .
+```
+vagrant plugin install vagrant-vbguest
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ You can look for output on `/var/log/cloud-init-output.log` or `/var/log/cloud-i
 ## Changing user-data
 To change diferent user-data configs, change the file `/vagrant/user_data.txt` at your heart's content .
 
+### Vagrant tools
+http://stackoverflow.com/questions/42074246/vagrant-error-unable-to-mount-virtualbox-shared-folders-guest-additions-vboxs
+
 ## License
 
 The lib is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -74,6 +74,6 @@ Vagrant.configure("2") do |config|
    config.vm.provision "shell", inline: <<-SHELL
      apt-get update
      apt-get install cloud-init ruby-rack vim curl -y
-     gem install sinatra
+     gem install sinatra -v 1.4.8
    SHELL
 end


### PR DESCRIPTION
Debian 8 is currently installing an old version o ruby. Sinatra requires ruby 2.3, so we need to downgrade it to continue using debian 8 .